### PR TITLE
Implemented keyboard input toggle

### DIFF
--- a/src/openseadragon.js
+++ b/src/openseadragon.js
@@ -531,6 +531,9 @@
   *     interactions include draging the image in a plane, and zooming in toward
   *     and away from the image.
   *
+  * @property {boolean} [keyboardNavEnabled=true]
+  *     Is the user able to interact with the image via keyboard.
+  *
   * @property {Boolean} [showNavigationControl=true]
   *     Set to false to prevent the appearance of the default navigation controls.<br>
   *     Note that if set to false, the customs buttons set by the options
@@ -1332,6 +1335,7 @@ function OpenSeadragon( options ){
             controlsFadeDelay:       2000,  //ZOOM/HOME/FULL/SEQUENCE
             controlsFadeLength:      1500,  //ZOOM/HOME/FULL/SEQUENCE
             mouseNavEnabled:         true,  //GENERAL MOUSE INTERACTIVITY
+            keyboardNavEnabled:      true,  //GENERAL KEYBOARD INTERACTIVITY
 
             //VIEWPORT NAVIGATOR SETTINGS
             showNavigator:              false,

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -986,6 +986,38 @@ $.extend( $.Viewer.prototype, $.EventSource.prototype, $.ControlDock.prototype, 
      * @function
      * @returns {Boolean}
      */
+    isKeyboardNavEnabled: function () {
+        return this.keyboardNavEnabled;
+    },
+
+    /**
+     * @function
+     * @param {Boolean} enabled - true to enable, false to disable
+     * @returns {OpenSeadragon.Viewer} Chainable.
+     * @fires OpenSeadragon.Viewer.event:keyboard-enabled
+     */
+    setKeyboardNavEnabled: function( enabled ){
+        this.keyboardNavEnabled = enabled;
+
+        /**
+         * Raised when keyboard navigation is enabled or disabled (see {@link OpenSeadragon.Viewer#setKeyboardNavEnabled}).
+         *
+         * @event keyboard-enabled
+         * @memberof OpenSeadragon.Viewer
+         * @type {object}
+         * @property {OpenSeadragon.Viewer} eventSource - A reference to the Viewer which raised the event.
+         * @property {Boolean} enabled
+         * @property {?Object} userData - Arbitrary subscriber-defined object.
+         */
+        this.raiseEvent( 'keyboard-enabled', { enabled: enabled } );
+        return this;
+    },
+
+
+    /**
+     * @function
+     * @returns {Boolean}
+     */
     areControlsEnabled: function () {
         var enabled = this.controls.length,
             i;
@@ -2848,7 +2880,7 @@ function onCanvasContextMenu( event ) {
 function onCanvasKeyDown( event ) {
     var canvasKeyDownEventArgs = {
       originalEvent: event.originalEvent,
-      preventDefaultAction: false,
+      preventDefaultAction: !this.keyboardNavEnabled,
       preventVerticalPan: event.preventVerticalPan || !this.panVertical,
       preventHorizontalPan: event.preventHorizontalPan || !this.panHorizontal
     };

--- a/test/demo/keyboardtoggle.html
+++ b/test/demo/keyboardtoggle.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>OpenSeadragon Keyboard Toggle Demo</title>
+    <script type="text/javascript" src='../../build/openseadragon/openseadragon.js'></script>
+    <script type="text/javascript" src='../lib/jquery-1.9.1.min.js'></script>
+    <style type="text/css">
+
+        .openseadragon1 {
+            width: 800px;
+            height: 600px;
+        }
+
+    </style>
+</head>
+<body>
+    <div>
+        Tests the keyboard toggling functionality. The keyboard is toggled to the opposite state every second.
+    </div>
+    <div id="contentDiv" class="openseadragon1"></div>
+    <script type="text/javascript">
+
+        var viewer = OpenSeadragon({
+            // debugMode: true,
+            id: "contentDiv",
+            prefixUrl: "../../build/openseadragon/images/",
+            tileSources: "../data/testpattern.dzi",
+            showNavigator: true,
+            keyboardNavEnabled: true
+        });
+
+        setInterval(() => {
+            viewer.setKeyboardNavEnabled(!viewer.isKeyboardNavEnabled());
+            console.log("isKeyboardNavEnabled: " + viewer.isKeyboardNavEnabled());
+        },1000)
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Issue: https://github.com/openseadragon/openseadragon/issues/794

A demo page testing the keyboard input toggle by automatically toggling it to the opposite state every second is available when built/tested locally at http://localhost:8000/test/demo/keyboardtoggle.html

With this PR, I added support to enable/disable keyboard input from OpenSeadragon options. For conformity, I copied the formatting for the `mouseNavEnabled` option, including its associated `isMouseNavEnabled()` and `setMouseNavEnabled(enabled)` functions. While `isKeyboardNavEnabled()` and `setKeyboardNavEnabled(enabled)` aren't strictly necessary because it only internally checks/modifies the `mouseNavEnabled` attribute, I chose to implement these as well to make it easier for developer intuition, as these functions exist for mouse input.

For the logic of the keyboard input toggle, all that was necessary was to change the default value of `preventDefaultAction` in the `onCanvasKeyDown(event)` to the current value of the `mouseNavEnabled` option.

